### PR TITLE
lib: fix AppInfoLayout memory leak in onDetachedFromWindow

### DIFF
--- a/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
+++ b/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -326,6 +327,24 @@ class AppInfoLayout(context: Context, attrs: AttributeSet?) : ToolbarLayout(cont
         ailContainer!!.post {
             updateButtonsWidth()
         }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        // Prevent AppCompatDelegateImpl.mActionBar → SemToolbar.mOnMenuItemClickListener → AppInfoLayout leak.
+        toolbar.setOnMenuItemClickListener(null)
+        // init() called setSupportActionBar(toolbar), so mActionBar retains this view hierarchy via
+        // ToolbarActionBar → SemToolbar.mParent. Restore the host ToolbarLayout's toolbar as the
+        // action bar to release that chain. mParent is still set here (cleared after detach).
+        var p: ViewParent? = parent
+        while (p != null) {
+            if (p is ToolbarLayout && p !== this) {
+                activity?.setSupportActionBar(p.toolbar)
+                return
+            }
+            p = (p as? View)?.parent
+        }
+        activity?.setSupportActionBar(null)
     }
 
     private fun updateButtonsWidth(){

--- a/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
+++ b/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
@@ -336,15 +336,16 @@ class AppInfoLayout(context: Context, attrs: AttributeSet?) : ToolbarLayout(cont
         // init() called setSupportActionBar(toolbar), so mActionBar retains this view hierarchy via
         // ToolbarActionBar → SemToolbar.mParent. Restore the host ToolbarLayout's toolbar as the
         // action bar to release that chain. mParent is still set here (cleared after detach).
+        val act = activity?.takeIf { !it.isDestroyed && !it.isFinishing } ?: return
         var p: ViewParent? = parent
         while (p != null) {
             if (p is ToolbarLayout && p !== this) {
-                activity?.setSupportActionBar(p.toolbar)
+                act.setSupportActionBar(p.toolbar)
                 return
             }
             p = (p as? View)?.parent
         }
-        activity?.setSupportActionBar(null)
+        act.setSupportActionBar(null)
     }
 
     private fun updateButtonsWidth(){

--- a/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
+++ b/lib/src/main/java/dev/oneuiproject/oneui/layout/AppInfoLayout.kt
@@ -341,6 +341,10 @@ class AppInfoLayout(context: Context, attrs: AttributeSet?) : ToolbarLayout(cont
         while (p != null) {
             if (p is ToolbarLayout && p !== this) {
                 act.setSupportActionBar(p.toolbar)
+                act.supportActionBar?.apply {
+                    setDisplayHomeAsUpEnabled(false)
+                    setDisplayShowTitleEnabled(false)
+                }
                 return
             }
             p = (p as? View)?.parent


### PR DESCRIPTION
## Summary

- Added `onDetachedFromWindow()` override that clears `toolbar.onMenuItemClickListener` and restores the host `ToolbarLayout`'s toolbar as the action bar
- `init()` calls `setSupportActionBar(toolbar)` which sets `AppCompatDelegateImpl.mActionBar` to a `ToolbarActionBar` wrapping our toolbar; this `ToolbarActionBar` holds `SemToolbar.mParent` keeping the entire `AppInfoLayout` view hierarchy alive after the fragment detaches
- The fix walks up the parent chain to find the host `ToolbarLayout` and restores its toolbar as the action bar, releasing the `mActionBar` chain
- Guard added: `activity?.takeIf { !it.isDestroyed && !it.isFinishing }` prevents crashes during activity teardown

## Test plan
- [ ] Navigate to/from a screen using `AppInfoLayout` repeatedly and verify LeakCanary reports no `AppInfoLayout`-related leaks
- [ ] Confirm action bar menu items and toolbar still function correctly after navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)